### PR TITLE
fix: updated C++ version to something younger than me

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ set(CMAKE_BUILD_TYPE Debug)
 
 project(project3-trie)
 
-set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD 23)
 
 include_directories(.)
 


### PR DESCRIPTION
Dearest Keith,

I wish to use `optional`s in my Trie assignment. I `trie`d to go without them, but the code became less readable. My dreams were shattered. 

So here I stand, praying for the use of a newer version. Please, consider my request.

I eagerly await your response, Elijah